### PR TITLE
Fix restart in free boundary mode by recomputing realspace r and z af…

### DIFF
--- a/Sources/blocktridiagonalsolver_s.f90
+++ b/Sources/blocktridiagonalsolver_s.f90
@@ -5297,7 +5297,6 @@ DO ic=1, M
       IF (lequi1) THEN
          scalevector(ic) = scalevector(ic) + SUM(coltmp)
          IF (js.EQ.endglobrow .AND. js.NE.N) THEN
-!WRITE (*,*) iam, js, "Bot"
             scalevector(ic) = scalevector(ic) + BotScaleFac(ic)
          END IF
       ELSE

--- a/Sources/metrics.f90
+++ b/Sources/metrics.f90
@@ -582,17 +582,17 @@
       INTEGER, INTENT(IN)                               :: nsmax
 
 !  Start executable code.
-      xsubsij = gss(:,nsmin:nsmax)*xsupsij                               &
-              + gsu(:,nsmin:nsmax)*xsupuij                               &
-              + gsv(:,nsmin:nsmax)*xsupvij
+      xsubsij(:,nsmin:nsmax) = gss(:,nsmin:nsmax)*xsupsij(:,nsmin:nsmax)       &
+                             + gsu(:,nsmin:nsmax)*xsupuij(:,nsmin:nsmax)       &
+                             + gsv(:,nsmin:nsmax)*xsupvij(:,nsmin:nsmax)
 
-      xsubuij = gsu(:,nsmin:nsmax)*xsupsij                               &
-              + guu(:,nsmin:nsmax)*xsupuij                               &
-              + guv(:,nsmin:nsmax)*xsupvij
+      xsubuij(:,nsmin:nsmax) = gsu(:,nsmin:nsmax)*xsupsij(:,nsmin:nsmax)       &
+                             + guu(:,nsmin:nsmax)*xsupuij(:,nsmin:nsmax)       &
+                             + guv(:,nsmin:nsmax)*xsupvij(:,nsmin:nsmax)
       
-      xsubvij = gsv(:,nsmin:nsmax)*xsupsij                               &
-              + guv(:,nsmin:nsmax)*xsupuij                               &
-              + gvv(:,nsmin:nsmax)*xsupvij
+      xsubvij(:,nsmin:nsmax) = gsv(:,nsmin:nsmax)*xsupsij(:,nsmin:nsmax)       &
+                             + guv(:,nsmin:nsmax)*xsupuij(:,nsmin:nsmax)       &
+                             + gvv(:,nsmin:nsmax)*xsupvij(:,nsmin:nsmax)
 
       END SUBROUTINE tolowerh
 

--- a/Sources/siesta_force.f90
+++ b/Sources/siesta_force.f90
@@ -118,16 +118,6 @@
                         bsupsijh, bsupuijh, bsupvijh, pijh, f_cos)
       END IF
 
-!      IF (nsmin .le. 5 .and. nsmax .ge. 5) THEN
-!         DO n = -ntor, ntor
-!            DO m = 0, mpol
-!               IF (jpmnch(m,n,5) .gt. 0.0 .or. djpmnch(m,n,6) .gt. 0.0) THEN
-!                  WRITE (*,*) iam, n, m, nsmin, nsmax, jpmnch(m,n,6), djpmnch(m,n,6)
-!               END IF
-!            END DO
-!         END DO
-!      END IF
-
 !  Update thermal energy (pressure based). pijh contains the jacobian term at
 !  this point.
       WPRES: IF (l_getwmhd) THEN


### PR DESCRIPTION
…ter determining the fourier modes. This reduces code since the grid externder doesn't need derivative quantities and reuses subroutines in metrics.