### PR TITLE
Ci fix

### DIFF
--- a/.github/workflows/ci_doxygen.yaml
+++ b/.github/workflows/ci_doxygen.yaml
@@ -23,6 +23,8 @@ jobs:
               shell: bash
               run: |
                 sudo apt update
+                sudo apt-get install libblas-dev
+                sudo apt-get install liblapack-dev
                 sudo apt-get install libnetcdf-dev
                 sudo apt-get install libnetcdff-dev
                 sudo apt-get install libopenmpi-dev


### PR DESCRIPTION
The doxygen runner needs the blast and lapack libraries to configure cmake.