### PR TITLE
Testing both phases in add_perturb can cause the island to randomly f…

### DIFF
--- a/Sources/siesta_namelist.f90
+++ b/Sources/siesta_namelist.f90
@@ -371,6 +371,12 @@
          END DO
       END IF
 
+!  The helical phase can only be 0 or 180 when lasym = false.
+      IF (.not.lasym) THEN
+         CALL assert(ALL(HelPhase .eq. 0.0 .or. HelPhase .eq. 180.0),          &
+     &               "When lasym is true helphase can only be 0 or 180.")
+      END IF
+
       END SUBROUTINE
 
 !-------------------------------------------------------------------------------

--- a/Sources/siesta_run.f90
+++ b/Sources/siesta_run.f90
@@ -643,7 +643,7 @@
 !>  @param[inout] this A @ref siesta_run_class instance.
 !-------------------------------------------------------------------------------
       SUBROUTINE siesta_run_sync(this)
-      USE siesta_namelist, ONLY: helpert
+      USE siesta_namelist, ONLY: helpert, helphase
       USE nscalingtools, ONLY: SIESTA_COMM, MPI_ERR
 #if defined(MPI_OPT)
       USE mpi_inc
@@ -660,6 +660,8 @@
                      MPI_ERR)
       IF (BTEST(this%control_state, siesta_run_sync_namelist)) THEN
          CALL MPI_BCAST(helpert, SIZE(helpert), MPI_REAL8, 0, SIESTA_COMM,     &
+                        MPI_ERR)
+         CALL MPI_BCAST(helphase, SIZE(helphase), MPI_REAL8, 0, SIESTA_COMM,   &
                         MPI_ERR)
          this%control_state = IBCLR(this%control_state,                        &
                                     siesta_run_sync_namelist)


### PR DESCRIPTION
…lip due to parallel reductions. For the phase to be fixed at either 0 or 180 when stellarator symmetry is enforced.